### PR TITLE
move logging to stderr, add "-" stdin/out

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -59,6 +59,13 @@ jobs:
           mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';"
           pip install . pytest
       - run: pytest tests_integration
+      - uses: actions/upload-artifact@v2
+        with:
+          name: integration_output
+          path: |
+            tests_integration/stdout.sql
+            tests_integration/basic.sql
+
 
   package: 
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+- Added ability to pipe output to/from pynonymizer from stdout, using `-` in place of the input/output arguments. This functionality is available for mssql and postgres providers.
 
-# [1.11.2] 2020-09-23
+  This means you can now use pynonymizer as part of a pipeline with other tools, e.g. 
+  ```
+  mysqldump [...] | pynonymizer -i - -o - | aws s3 cp - s3://bucket/aws-test.tar.gz 
+  ```
+
+
+## [1.11.2] 2020-09-23
 - Changed package metadata to improve PyPI presence.
 
 ## [1.11.1] 2020-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   ```
   mysqldump [...] | pynonymizer -i - -o - | aws s3 cp - s3://bucket/aws-test.tar.gz 
   ```
-
+- Removed production logging feature in favour of stderr/out logging. logging to files will no longer by considered pynonymizer's concern.
 
 ## [1.11.2] 2020-09-23
 - Changed package metadata to improve PyPI presence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   ```
   mysqldump [...] | pynonymizer -i - -o - | aws s3 cp - s3://bucket/aws-test.tar.gz 
   ```
-- Removed production logging feature in favour of stderr/out logging. logging to files will no longer by considered pynonymizer's concern.
+- Changed default logging output to stderr. This is to facilitate stdin/out being used for data.
+- Removed production logging feature in favour of stderr/out logging. Logging to files will no longer by considered pynonymizer's concern.
 
 ## [1.11.2] 2020-09-23
 - Changed package metadata to improve PyPI presence.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
-# pynonymizer
-
-[![Downloads](https://pepy.tech/badge/pynonymizer)](https://pepy.tech/project/pynonymizer)
-![License](https://img.shields.io/pypi/l/pynonymizer)
+# `pynonymizer` [![pynonymizer on PyPI](https://img.shields.io/pypi/v/pynonymizer)](https://pypi.org/project/pynonymizer/) [![Downloads](https://pepy.tech/badge/pynonymizer)](https://pepy.tech/project/pynonymizer) ![License](https://img.shields.io/pypi/l/pynonymizer)
 
 pynonymizer is a universal tool for translating sensitive production database dumps into anonymized copies.
 
 This can help you support GDPR/Data Protection in your organization without compromizing on quality testing data.
 
-* [pynonymizer on PyPI](https://pypi.org/project/pynonymizer/)
-
-### Why are anonymized databases important?
+## Why are anonymized databases important?
 The primary source of information on how your database is used is in _your production database_. In most situations, the production dataset is usually significantly larger than any development copy, and
 would contain a wider range of data.
 
@@ -24,18 +19,18 @@ below is an excerpt from an anonymized database:
 
 | id |salutation | firstname | surname | email | dob |
 | - | - | - | - | - | - |
-| 1 | Dr. | Bernard | Gough | tnelson@powell.com | 2000-07-03 |
-| 2 | Mr. | Molly | Bennett | clarkeharriet@price-fry.com | 2014-05-19 |
-| 3 | Mrs. | Chelsea | Reid | adamsamber@clayton.com | 1974-09-08 |
-| 4 | Dr. | Grace | Armstrong | tracy36@wilson-matthews.com | 1963-12-15 |
-| 5 | Dr. | Stanley | James | christine15@stewart.net | 1976-09-16 |
-| 6 | Dr. | Mark | Walsh | dgardner@ward.biz | 2004-08-28 |
-| 7 | Mrs. | Josephine | Chambers | hperry@allen.com | 1916-04-04 |
-| 8 | Dr. | Stephen | Thomas | thompsonheather@smith-stevens.com | 1995-04-17 |
-| 9 | Ms. | Damian | Thompson | yjones@cox.biz | 2016-10-02 |
-| 10 | Miss | Geraldine | Harris | porteralice@francis-patel.com | 1910-09-28 |
-| 11 | Ms. | Gemma | Jones | mandylewis@patel-thomas.net | 1990-06-03 |
-| 12 | Dr. | Glenn | Carr | garnervalerie@farrell-parsons.biz | 1998-04-19 |
+| 1 | Dr. | Bernard | Gough | `tnelson@powell.com` | 2000-07-03 |
+| 2 | Mr. | Molly | Bennett | `clarkeharriet@price-fry.com` | 2014-05-19 |
+| 3 | Mrs. | Chelsea | Reid | `adamsamber@clayton.com` | 1974-09-08 |
+| 4 | Dr. | Grace | Armstrong | `tracy36@wilson-matthews.com` | 1963-12-15 |
+| 5 | Dr. | Stanley | James | `christine15@stewart.net` | 1976-09-16 |
+| 6 | Dr. | Mark | Walsh | `dgardner@ward.biz` | 2004-08-28 |
+| 7 | Mrs. | Josephine | Chambers | `hperry@allen.com` | 1916-04-04 |
+| 8 | Dr. | Stephen | Thomas | `thompsonheather@smith-stevens.com` | 1995-04-17 |
+| 9 | Ms. | Damian | Thompson | `yjones@cox.biz` | 2016-10-02 |
+| 10 | Miss | Geraldine | Harris | `porteralice@francis-patel.com` | 1910-09-28 |
+| 11 | Ms. | Gemma | Jones | `mandylewis@patel-thomas.net` | 1990-06-03 |
+| 12 | Dr. | Glenn | Carr | `garnervalerie@farrell-parsons.biz` | 1998-04-19 |
 
 
 ## How does it work?

--- a/pynonymizer/database/basic/input.py
+++ b/pynonymizer/database/basic/input.py
@@ -1,6 +1,7 @@
 import os
 import struct
 import gzip
+import sys
 """
 Streaming input files for streamable providers
 """
@@ -41,8 +42,18 @@ class RawInput:
     def open(self):
         return open(self.filename, "rb")
 
+class StdInInput:
+    def get_size(self):
+        return None
+
+    def open(self):
+        return sys.stdin
+
 
 def resolve_input(filename):
+    if filename == "-":
+        return StdInInput()
+
     name, ext = os.path.splitext(filename)
 
     if ext == ".sql":

--- a/pynonymizer/database/basic/input.py
+++ b/pynonymizer/database/basic/input.py
@@ -47,7 +47,7 @@ class StdInInput:
         return None
 
     def open(self):
-        return sys.stdin
+        return sys.stdin.buffer
 
 
 def resolve_input(filename):

--- a/pynonymizer/database/basic/output.py
+++ b/pynonymizer/database/basic/output.py
@@ -28,7 +28,7 @@ class RawOutput:
 
 class StdOutOutput:
     def open(self):
-        return sys.stdout
+        return sys.stdout.buffer
 
 def resolve_output(filename):
     if filename == "-":

--- a/pynonymizer/database/basic/output.py
+++ b/pynonymizer/database/basic/output.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import sys
 """
 Streaming output files for streamable providers
 """
@@ -25,8 +26,14 @@ class RawOutput:
     def open(self):
         return open(self.filename, "wb")
 
+class StdOutOutput:
+    def open(self):
+        return sys.stdout
 
 def resolve_output(filename):
+    if filename == "-":
+        return StdOutOutput()
+
     name, ext = os.path.splitext(filename)
 
     if ext == ".sql":

--- a/pynonymizer/log.py
+++ b/pynonymizer/log.py
@@ -42,12 +42,4 @@ def init_logging():
     console_handler.setFormatter(default_console_formatter)
     default_logger.addHandler(console_handler)
 
-    # Add default file handler when running in production
-    if os.getenv("env_type") == "production":
-        file_handler = logging.FileHandler('pynonymizer.log')
-        file_handler.setLevel(logging.INFO)
-        file_handler.setFormatter(default_file_formatter)
-        default_logger.addHandler(file_handler)
-
-
 init_logging()

--- a/pynonymizer/log.py
+++ b/pynonymizer/log.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 
 def get_default_logger():
     """
@@ -36,7 +37,7 @@ def init_logging():
     default_console_formatter = logging.Formatter('%(message)s')
 
     # Add default warn handler to console
-    console_handler = logging.StreamHandler()
+    console_handler = logging.StreamHandler(sys.stderr)
     console_handler.setLevel(logging.INFO)
     console_handler.setFormatter(default_console_formatter)
     default_logger.addHandler(console_handler)

--- a/tests/database/basic/test_input.py
+++ b/tests/database/basic/test_input.py
@@ -30,10 +30,10 @@ def test_raw_open():
         assert open_result == mock_file.return_value
 
 def test_stdin_open():
-    with patch("sys.stdin.buffer") as mock_file:
+    with patch("sys.stdin") as mock_stdin:
         std = StdInInput()
 
-        assert std.open() == mock_file
+        assert std.open() is mock_stdin.buffer
 
 @patch("os.path.getsize", autospec=True)
 def test_raw_get_size(getsize):

--- a/tests/database/basic/test_input.py
+++ b/tests/database/basic/test_input.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest import TestCase
 from unittest.mock import mock_open, patch
-from pynonymizer.database.basic.input import GzipInput, RawInput, UnknownInputTypeError, resolve_input
+from pynonymizer.database.basic.input import GzipInput, RawInput, UnknownInputTypeError, resolve_input, StdInInput
 
 
 def test_gzip_open():
@@ -29,6 +29,11 @@ def test_raw_open():
 
         assert open_result == mock_file.return_value
 
+def test_stdin_open():
+    with patch("sys.stdin", mock_open(read_data=b"data2")) as mock_file:
+        std = StdInInput()
+
+        assert std.open() == mock_file.return_value
 
 @patch("os.path.getsize", autospec=True)
 def test_raw_get_size(getsize):
@@ -40,6 +45,9 @@ def test_raw_get_size(getsize):
     size_result = raw.get_size()
     assert size_result == getsize.return_value
 
+
+def test_resolve_stdin():
+    assert isinstance(resolve_input("-"), StdInInput)
 
 class ResolveFromFilepathTest(TestCase):
     test_path_examples = [

--- a/tests/database/basic/test_input.py
+++ b/tests/database/basic/test_input.py
@@ -30,7 +30,7 @@ def test_raw_open():
         assert open_result == mock_file.return_value
 
 def test_stdin_open():
-    with patch("sys.stdin") as mock_file:
+    with patch("sys.stdin.buffer") as mock_file:
         std = StdInInput()
 
         assert std.open() == mock_file

--- a/tests/database/basic/test_input.py
+++ b/tests/database/basic/test_input.py
@@ -30,10 +30,10 @@ def test_raw_open():
         assert open_result == mock_file.return_value
 
 def test_stdin_open():
-    with patch("sys.stdin", mock_open(read_data=b"data2")) as mock_file:
+    with patch("sys.stdin") as mock_file:
         std = StdInInput()
 
-        assert std.open() == mock_file.return_value
+        assert std.open() == mock_file
 
 @patch("os.path.getsize", autospec=True)
 def test_raw_get_size(getsize):

--- a/tests/database/basic/test_output.py
+++ b/tests/database/basic/test_output.py
@@ -31,7 +31,7 @@ def test_resolve_stdout():
     isinstance(resolve_output("-"), StdOutOutput)
 
 def test_stdout_open():
-    with patch("sys.stdout") as mock_file:
+    with patch("sys.stdout.buffer") as mock_file:
         std = StdOutOutput()
 
         assert std.open() == mock_file

--- a/tests/database/basic/test_output.py
+++ b/tests/database/basic/test_output.py
@@ -31,7 +31,7 @@ def test_resolve_stdout():
     isinstance(resolve_output("-"), StdOutOutput)
 
 def test_stdout_open():
-    with patch("sys.stdout" as mock_file:
+    with patch("sys.stdout") as mock_file:
         std = StdOutOutput()
 
         assert std.open() == mock_file

--- a/tests/database/basic/test_output.py
+++ b/tests/database/basic/test_output.py
@@ -1,4 +1,5 @@
-from pynonymizer.database.basic.output import UnknownOutputTypeError, resolve_output, RawOutput, GzipOutput
+from pynonymizer.database.basic.output import UnknownOutputTypeError, resolve_output, RawOutput, GzipOutput, StdOutOutput
+from unittest.mock import mock_open, patch
 import pytest
 
 test_path_examples = [
@@ -25,3 +26,12 @@ def test_resolve_gzip(path_example):
 def test_resolve_unknown():
     with pytest.raises(UnknownOutputTypeError):
         resolve_output("unknown_file.bbs")
+
+def test_resolve_stdout():
+    isinstance(resolve_output("-"), StdOutOutput)
+
+def test_stdout_open():
+    with patch("sys.stdout" as mock_file:
+        std = StdOutOutput()
+
+        assert std.open() == mock_file

--- a/tests/database/basic/test_output.py
+++ b/tests/database/basic/test_output.py
@@ -31,7 +31,7 @@ def test_resolve_stdout():
     isinstance(resolve_output("-"), StdOutOutput)
 
 def test_stdout_open():
-    with patch("sys.stdout.buffer") as mock_file:
+    with patch("sys.stdout") as mock_stdout:
         std = StdOutOutput()
 
-        assert std.open() == mock_file
+        assert std.open() is mock_stdout.buffer

--- a/tests_integration/test_integration.py
+++ b/tests_integration/test_integration.py
@@ -16,12 +16,12 @@ def test_basic():
     output = subprocess.check_output([
         "pynonymizer",
         "-i", "sakila.sql.gz",
-        "-o", "output.sql",
+        "-o", "basic.sql",
         "-s", "sakila.yml"
         ],
         cwd=test_dir
     )
-    output_path = os.path.join(test_dir, "./output.sql")
+    output_path = os.path.join(test_dir, "./basic.sql")
 
     # some very rough output checks
     assert os.path.exists(output_path)

--- a/tests_integration/test_integration.py
+++ b/tests_integration/test_integration.py
@@ -26,3 +26,18 @@ def test_basic():
     assert os.path.exists(output_path)
     assert os.path.getsize(output_path) > 3 * ONE_MB
 
+@pytest.mark.integration
+def test_basic_stdin_stdout():
+    """
+        Perform an actual run against the local database using the modified sakila DB
+        perform some basic checks against the output file
+    """
+    strat_path = os.path.join(test_dir, "sakila.yml")
+
+    p = subprocess.check_output(f"gunzip -c sakila.sql.gz | pynonymizer -i - -o - -s \"{strat_path}\" > stdout.sql", shell=True )
+
+    output_path = "stdout.sql"
+    # some very rough output checks
+    assert os.path.exists(output_path)
+    assert os.path.getsize(output_path) > 3 * ONE_MB
+

--- a/tests_integration/test_integration.py
+++ b/tests_integration/test_integration.py
@@ -15,10 +15,11 @@ def test_basic():
     """
     output = subprocess.check_output([
         "pynonymizer",
-        "-i", os.path.join(test_dir, "sakila.sql.gz"),
-        "-o", os.path.join(test_dir, "output.sql"),
-        "-s", os.path.join(test_dir, "sakila.yml")
-        ]
+        "-i", "sakila.sql.gz",
+        "-o", "output.sql",
+        "-s", "sakila.yml"
+        ],
+        cwd=test_dir
     )
     output_path = os.path.join(test_dir, "./output.sql")
 
@@ -28,15 +29,9 @@ def test_basic():
 
 @pytest.mark.integration
 def test_basic_stdin_stdout():
-    """
-        Perform an actual run against the local database using the modified sakila DB
-        perform some basic checks against the output file
-    """
-    strat_path = os.path.join(test_dir, "sakila.yml")
+    p = subprocess.check_output(f"gunzip -c sakila.sql.gz | pynonymizer -i - -o - -s sakila.yml > stdout.sql", shell=True, cwd=test_dir )
 
-    p = subprocess.check_output(f"gunzip -c sakila.sql.gz | pynonymizer -i - -o - -s \"{strat_path}\" > stdout.sql", shell=True )
-
-    output_path = "stdout.sql"
+    output_path = os.path.join(test_dir, "./stdout.sql")
     # some very rough output checks
     assert os.path.exists(output_path)
     assert os.path.getsize(output_path) > 3 * ONE_MB


### PR DESCRIPTION
This is a bit of a change to the way logging is performed and it might
need some additional attention to make it seamless.

I'm treating stdin/out as files directly and using the filepath "-" to
denote the pipe. you should be able to use this like:

```
mysqldump | pynonymizer -i - -o - | other-process
```