### PR TITLE
fix: allow usage of postgresql keywords as columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   -------------------------------------------------------------------
 ## [Unreleased]
 
+- Fixed PostgreSQL column escaping. Keywords like `SELECT`, `FROM` or `WHERE` can now be used in strategy files.
+
 ## [1.13.0] 2020-10-22
 - Added new table strategy `DELETE`, which should delete _with_ checks (e.g. foreign keys) on most providers. 
 

--- a/pynonymizer/database/postgres/query_factory.py
+++ b/pynonymizer/database/postgres/query_factory.py
@@ -103,7 +103,7 @@ def get_update_table(seed_table_name, update_table_strategy):
     for where, column_map in update_table_strategy.group_by_where().items():
         where_update_statements[where] = []
         for column_name, column_strategy in column_map.items():
-            where_update_statements[where].append("{} = {}".format(
+            where_update_statements[where].append("\"{}\" = {}".format(
                 column_name,
                 _get_column_subquery(seed_table_name, column_strategy))
             )

--- a/tests/database/postgres/test_query_factory.py
+++ b/tests/database/postgres/test_query_factory.py
@@ -173,12 +173,12 @@ def test_get_update_table_fake_column(column_strategy_list):
 
     assert update_table_all == [
             "UPDATE anon_table AS \"updatetarget\" SET "
-            "test_column1 = ( SELECT first_name FROM seed_table WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1),"
-            "test_column2 = ( SELECT last_name FROM seed_table WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1),"
-            "test_column3 = (''),"
-            "test_column4 = ( SELECT md5(random()::text) WHERE \"updatetarget\"=\"updatetarget\" ),"
-            "test_column5 = ( SELECT CONCAT(md5(random()::text), '@', md5(random()::text), '.com') WHERE \"updatetarget\"=\"updatetarget\" ),"
-            "test_column6 = RANDOM();"
+            "\"test_column1\" = ( SELECT first_name FROM seed_table WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1),"
+            "\"test_column2\" = ( SELECT last_name FROM seed_table WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1),"
+            "\"test_column3\" = (''),"
+            "\"test_column4\" = ( SELECT md5(random()::text) WHERE \"updatetarget\"=\"updatetarget\" ),"
+            "\"test_column5\" = ( SELECT CONCAT(md5(random()::text), '@', md5(random()::text), '.com') WHERE \"updatetarget\"=\"updatetarget\" ),"
+            "\"test_column6\" = RANDOM();"
             ]
 
 
@@ -189,5 +189,5 @@ def test_get_update_table_literal(literal_strategy):
     ]))
 
     assert result_queries == [
-        "UPDATE anon_table AS \"updatetarget\" SET literal_column = RANDOM();"
+        "UPDATE anon_table AS \"updatetarget\" SET \"literal_column\" = RANDOM();"
     ]


### PR DESCRIPTION
Fix an issue when using fields that are PostgreSQL keywords.

For example, this query will fail:

```yaml
tables:
  my_table:
    columns:
      from: uuid4 # this field is a keyword and will fail
```

This PR patch this issue by escaping SQL fields in `UPDATE` query.