### PR TITLE
feat: allow definition of sql type

### DIFF
--- a/doc/strategyfiles.md
+++ b/doc/strategyfiles.md
@@ -175,9 +175,6 @@ This will not perform escaping for your language, so you must ensure that it is 
 column_name:
   type: literal
   value: RAND()
-  # Optional, define the SQL type in the database.
-  # The value will not be escaped, it will be a raw SQL type so be careful.
-  sql_type: INT
 
 # Compact Syntax: Not available
 ```

--- a/doc/strategyfiles.md
+++ b/doc/strategyfiles.md
@@ -168,13 +168,16 @@ column_name: unique_email
 ```
 
 #### Column Strategy: `literal`
-Replace a column with the value specified. 
+Replace a column with the value specified.
 
 This will not perform escaping for your language, so you must ensure that it is correct and executable by your provider.
 ```yaml
-column_name: 
+column_name:
   type: literal
   value: RAND()
+  # Optional, define the SQL type in the database.
+  # The value will not be escaped, it will be a raw SQL type so be careful.
+  sql_type: INT
 
 # Compact Syntax: Not available
 ```
@@ -190,8 +193,11 @@ column_name:
   # For example: fake.file_path(depth=1, category=None, extension=None)
   fake_args:
     depth: 1
-    
-  
+  # Optional, define the SQL type in the database.
+  # The value will not be escaped, it will be a raw SQL type so be careful.
+  sql_type: VARCHAR(255)
+
+
 # Compact Syntax: specify any supported faker method string, excluding the keywords `empty`, `unique_login`, `unique_email`
 column_name: file_path
 ```

--- a/pynonymizer/database/mssql/__init__.py
+++ b/pynonymizer/database/mssql/__init__.py
@@ -208,10 +208,10 @@ class MsSqlProvider(DatabaseProvider):
         elif column_strategy.strategy_type == UpdateColumnStrategyTypes.UNIQUE_LOGIN:
             return f"( SELECT NEWID() )"
         elif column_strategy.strategy_type == UpdateColumnStrategyTypes.FAKE_UPDATE:
-            column = column_strategy.qualifier
+            column = f"[{column_strategy.qualifier}]"
             if column_strategy.sql_type:
-                column += "::" + column_strategy.sql_type
-            return f"( SELECT TOP 1 [{column}] FROM [{SEED_TABLE_NAME}] ORDER BY NEWID())"
+                column = f"CAST({column} AS {column_strategy.sql_type})"
+            return f"( SELECT TOP 1 {column} FROM [{SEED_TABLE_NAME}] ORDER BY NEWID())"
         elif column_strategy.strategy_type == UpdateColumnStrategyTypes.LITERAL:
             return column_strategy.value
         else:
@@ -231,7 +231,7 @@ class MsSqlProvider(DatabaseProvider):
         if len(qualifier_map) > 0:
             self.logger.info("creating seed table with %d columns", len(qualifier_map))
             self.__create_seed_table(qualifier_map)
-            
+
             self.logger.info("Inserting seed data")
             self.__seed(qualifier_map)
 

--- a/pynonymizer/database/mssql/__init__.py
+++ b/pynonymizer/database/mssql/__init__.py
@@ -180,7 +180,7 @@ class MsSqlProvider(DatabaseProvider):
             self.logger.info(results)
 
     def __create_seed_table(self, qualifier_map):
-        seed_column_lines = ["[{}] {}".format(name, _FAKE_COLUMN_TYPES[col.data_type]) for name, col in qualifier_map.items()]
+        seed_column_lines = ["[{}] {}".format(name, col.sql_type or _FAKE_COLUMN_TYPES[col.data_type]) for name, col in qualifier_map.items()]
         create_statement = "CREATE TABLE [{}]({});".format(SEED_TABLE_NAME, ",".join(seed_column_lines))
 
         self.__db_execute(create_statement)
@@ -228,7 +228,7 @@ class MsSqlProvider(DatabaseProvider):
         if len(qualifier_map) > 0:
             self.logger.info("creating seed table with %d columns", len(qualifier_map))
             self.__create_seed_table(qualifier_map)
-            
+
             self.logger.info("Inserting seed data")
             self.__seed(qualifier_map)
 

--- a/pynonymizer/database/mysql/query_factory.py
+++ b/pynonymizer/database/mysql/query_factory.py
@@ -17,8 +17,8 @@ _FAKE_COLUMN_TYPES = {
 _RAND_MD5 = "MD5(FLOOR((NOW() + RAND()) * (RAND() * RAND() / RAND()) + RAND()))"
 
 
-def _get_sql_type(data_type):
-    return _FAKE_COLUMN_TYPES[data_type]
+def _get_sql_type(strategy):
+    return strategy.sql_type or _FAKE_COLUMN_TYPES[strategy.data_type]
 
 
 def _get_column_subquery(seed_table_name, column_strategy):
@@ -58,7 +58,7 @@ def get_create_seed_table(table_name, qualifier_map):
     if len(qualifier_map) < 1:
         raise ValueError("Cannot create a seed table with no columns")
 
-    create_columns = [f"`{qualifier}` {_get_sql_type(strategy.data_type)}" for qualifier, strategy in qualifier_map.items()]
+    create_columns = [f"`{qualifier}` {_get_sql_type(strategy)}" for qualifier, strategy in qualifier_map.items()]
 
     return "CREATE TABLE `{}` ({});".format(table_name, ",".join(create_columns) )
 

--- a/pynonymizer/database/mysql/query_factory.py
+++ b/pynonymizer/database/mysql/query_factory.py
@@ -29,10 +29,10 @@ def _get_column_subquery(seed_table_name, column_strategy):
     elif column_strategy.strategy_type == UpdateColumnStrategyTypes.UNIQUE_LOGIN:
         return f"( SELECT {_RAND_MD5} )"
     elif column_strategy.strategy_type == UpdateColumnStrategyTypes.FAKE_UPDATE:
-        column = column_strategy.qualifier
+        column = f"`{column_strategy.qualifier}`"
         if column_strategy.sql_type:
-            column += "::" + column_strategy.sql_type
-        return f"( SELECT `{column}` FROM `{seed_table_name}` ORDER BY RAND() LIMIT 1)"
+            column = f"CAST({column} AS {column_strategy.sql_type})"
+        return f"( SELECT {column} FROM `{seed_table_name}` ORDER BY RAND() LIMIT 1)"
     elif column_strategy.strategy_type == UpdateColumnStrategyTypes.LITERAL:
         return column_strategy.value
     else:

--- a/pynonymizer/database/mysql/query_factory.py
+++ b/pynonymizer/database/mysql/query_factory.py
@@ -17,8 +17,8 @@ _FAKE_COLUMN_TYPES = {
 _RAND_MD5 = "MD5(FLOOR((NOW() + RAND()) * (RAND() * RAND() / RAND()) + RAND()))"
 
 
-def _get_sql_type(strategy):
-    return strategy.sql_type or _FAKE_COLUMN_TYPES[strategy.data_type]
+def _get_sql_type(data_type):
+    return _FAKE_COLUMN_TYPES[data_type]
 
 
 def _get_column_subquery(seed_table_name, column_strategy):
@@ -29,7 +29,10 @@ def _get_column_subquery(seed_table_name, column_strategy):
     elif column_strategy.strategy_type == UpdateColumnStrategyTypes.UNIQUE_LOGIN:
         return f"( SELECT {_RAND_MD5} )"
     elif column_strategy.strategy_type == UpdateColumnStrategyTypes.FAKE_UPDATE:
-        return f"( SELECT `{column_strategy.qualifier}` FROM `{seed_table_name}` ORDER BY RAND() LIMIT 1)"
+        column = column_strategy.qualifier
+        if column_strategy.sql_type:
+            column += "::" + column_strategy.sql_type
+        return f"( SELECT `{column}` FROM `{seed_table_name}` ORDER BY RAND() LIMIT 1)"
     elif column_strategy.strategy_type == UpdateColumnStrategyTypes.LITERAL:
         return column_strategy.value
     else:
@@ -58,7 +61,7 @@ def get_create_seed_table(table_name, qualifier_map):
     if len(qualifier_map) < 1:
         raise ValueError("Cannot create a seed table with no columns")
 
-    create_columns = [f"`{qualifier}` {_get_sql_type(strategy)}" for qualifier, strategy in qualifier_map.items()]
+    create_columns = [f"`{qualifier}` {_get_sql_type(strategy.data_type)}" for qualifier, strategy in qualifier_map.items()]
 
     return "CREATE TABLE `{}` ({});".format(table_name, ",".join(create_columns) )
 

--- a/pynonymizer/database/postgres/query_factory.py
+++ b/pynonymizer/database/postgres/query_factory.py
@@ -16,8 +16,8 @@ _FAKE_COLUMN_TYPES = {
 _RAND_MD5 = "md5(random()::text)"
 
 
-def _get_sql_type(strategy):
-    return strategy.sql_type or _FAKE_COLUMN_TYPES[strategy.data_type]
+def _get_sql_type(data_type):
+    return _FAKE_COLUMN_TYPES[data_type]
 
 
 def _get_column_subquery(seed_table_name, column_strategy):
@@ -31,7 +31,10 @@ def _get_column_subquery(seed_table_name, column_strategy):
         # Add a dummy "updatetarget" where clause to fool the postgres optimizer into running the subquery on every row
         # instead of once for the whole query
         # See Also https://www.simononsoftware.com/problem-with-random-in-postgresql-subselect/
-        return f"( SELECT {column_strategy.qualifier} FROM {seed_table_name} WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1)"
+        column = column_strategy.qualifier
+        if column_strategy.sql_type:
+            column += "::" + column_strategy.sql_type
+        return f"( SELECT {column} FROM {seed_table_name} WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1)"
     elif column_strategy.strategy_type == UpdateColumnStrategyTypes.LITERAL:
         return column_strategy.value
     else:
@@ -66,7 +69,7 @@ def get_create_seed_table(table_name, qualifier_map):
     if len(qualifier_map) < 1:
         raise ValueError("Cannot create a seed table with no columns")
 
-    create_columns = [f"{qualifier} {_get_sql_type(strategy)}" for qualifier, strategy in qualifier_map.items()]
+    create_columns = [f"{qualifier} {_get_sql_type(strategy.data_type)}" for qualifier, strategy in qualifier_map.items()]
 
     return "CREATE TABLE {} ({});".format(table_name, ",".join(create_columns) )
 

--- a/pynonymizer/database/postgres/query_factory.py
+++ b/pynonymizer/database/postgres/query_factory.py
@@ -16,8 +16,8 @@ _FAKE_COLUMN_TYPES = {
 _RAND_MD5 = "md5(random()::text)"
 
 
-def _get_sql_type(data_type):
-    return _FAKE_COLUMN_TYPES[data_type]
+def _get_sql_type(strategy):
+    return strategy.sql_type or _FAKE_COLUMN_TYPES[strategy.data_type]
 
 
 def _get_column_subquery(seed_table_name, column_strategy):
@@ -66,7 +66,7 @@ def get_create_seed_table(table_name, qualifier_map):
     if len(qualifier_map) < 1:
         raise ValueError("Cannot create a seed table with no columns")
 
-    create_columns = [f"{qualifier} {_get_sql_type(strategy.data_type)}" for qualifier, strategy in qualifier_map.items()]
+    create_columns = [f"{qualifier} {_get_sql_type(strategy)}" for qualifier, strategy in qualifier_map.items()]
 
     return "CREATE TABLE {} ({});".format(table_name, ",".join(create_columns) )
 

--- a/pynonymizer/strategy/update_column.py
+++ b/pynonymizer/strategy/update_column.py
@@ -43,20 +43,22 @@ class UniqueEmailUpdateColumnStrategy(UpdateColumnStrategy):
 class LiteralUpdateColumnStrategy(UpdateColumnStrategy):
     strategy_type = UpdateColumnStrategyTypes.LITERAL
 
-    def __init__(self, column_name,  value, where=None):
+    def __init__(self, column_name,  value, where=None, sql_type=None):
         super().__init__(column_name, where)
         self.value = value
+        self.sql_type = sql_type
 
 
 class FakeUpdateColumnStrategy(UpdateColumnStrategy):
     strategy_type = UpdateColumnStrategyTypes.FAKE_UPDATE
 
-    def __init__(self, column_name, fake_column_generator, fake_type, where=None, fake_args=None):
+    def __init__(self, column_name, fake_column_generator, fake_type, where=None, fake_args=None, sql_type=None):
         fake_args = {} if fake_args is None else fake_args
         super().__init__(column_name, where)
         self.fake_type = fake_type
         self.fake_args = fake_args
         self.__fake_column_generator = fake_column_generator
+        self.sql_type = sql_type
 
         if not fake_column_generator.supports(fake_type, fake_args):
             raise UnsupportedFakeTypeError(fake_type, fake_args)
@@ -71,7 +73,7 @@ class FakeUpdateColumnStrategy(UpdateColumnStrategy):
         """
         sorted_args = "_".join( [f"{arg}_{value}" for arg, value in sorted(self.fake_args.items(), key=lambda item: item[0])] )
         args_hash = hashlib.md5(bytes(sorted_args, "utf8")).hexdigest()
-        
+
         # keep the whole thing below 64chars for maximum database compatibility
         return (self.fake_type + (("_" + args_hash) if sorted_args else ""))[:64]
 

--- a/pynonymizer/strategy/update_column.py
+++ b/pynonymizer/strategy/update_column.py
@@ -43,10 +43,9 @@ class UniqueEmailUpdateColumnStrategy(UpdateColumnStrategy):
 class LiteralUpdateColumnStrategy(UpdateColumnStrategy):
     strategy_type = UpdateColumnStrategyTypes.LITERAL
 
-    def __init__(self, column_name,  value, where=None, sql_type=None):
+    def __init__(self, column_name,  value, where=None):
         super().__init__(column_name, where)
         self.value = value
-        self.sql_type = sql_type
 
 
 class FakeUpdateColumnStrategy(UpdateColumnStrategy):

--- a/tests/database/mysql/test_query_factory.py
+++ b/tests/database/mysql/test_query_factory.py
@@ -16,9 +16,9 @@ from pynonymizer.strategy.update_column import (
 import pynonymizer.database.mysql.query_factory as query_factory
 
 """
-These tests are brittle and based on the actual SQL generatedColumnStrategyTypes. 
+These tests are brittle and based on the actual SQL generatedColumnStrategyTypes.
 The sentiment is to test the 'meaning' of the SQL, rather than the actual formatting, so it may be prudent to replace
-these tests with some form of parsing or pattern matching. 
+these tests with some form of parsing or pattern matching.
 
 The general idea, however, is that by keeping the queryfactory separate from the provider, it will not change often,
 and the sql returned should be very stable.
@@ -61,6 +61,12 @@ def int_fake_column_generator():
         get_data_type=Mock(return_value=FakeDataType.INT),
         get_value=Mock(return_value=645)
     )
+@pytest.fixture
+def uuid_fake_column_generator():
+    return Mock(
+        get_data_type=Mock(return_value="UUID"),
+        get_value=Mock(return_value="d4b7d972-99c9-4c0f-83c0-4cf2c63fd6ed")
+    )
 
 
 @pytest.fixture
@@ -71,6 +77,11 @@ def fake_update_column_str_first_name(str_fake_column_generator):
 @pytest.fixture
 def fake_update_column_int_last_name(int_fake_column_generator):
     return FakeUpdateColumnStrategy("test_column2",int_fake_column_generator, "last_name")
+
+
+@pytest.fixture
+def fake_update_column_uuid_user_id(uuid_fake_column_generator):
+    return FakeUpdateColumnStrategy("test_column7", uuid_fake_column_generator, "user_id", sql_type="UUID")
 
 
 @pytest.fixture
@@ -108,10 +119,11 @@ def qualifier_column_map(fake_update_column_str_first_name,fake_update_column_in
 
 
 @pytest.fixture
-def column_strategy_list(fake_update_column_str_first_name,fake_update_column_int_last_name,empty_strategy,ulogin_strategy, uemail_strategy,literal_strategy):
+def column_strategy_list(fake_update_column_str_first_name,fake_update_column_int_last_name,fake_update_column_uuid_user_id,empty_strategy,ulogin_strategy, uemail_strategy,literal_strategy):
     return [
         fake_update_column_str_first_name,
         fake_update_column_int_last_name,
+        fake_update_column_uuid_user_id,
         empty_strategy,
         ulogin_strategy,
         uemail_strategy,
@@ -171,6 +183,7 @@ def test_get_update_table_fake_column(column_strategy_list):
             "UPDATE `anon_table` SET "
             "`test_column1` = ( SELECT `first_name` FROM `seed_table` ORDER BY RAND() LIMIT 1),"
             "`test_column2` = ( SELECT `last_name` FROM `seed_table` ORDER BY RAND() LIMIT 1),"
+            "`test_column7` = ( SELECT `user_id::UUID` FROM `seed_table` ORDER BY RAND() LIMIT 1),"
             "`test_column3` = (''),"
             "`test_column4` = ( SELECT MD5(FLOOR((NOW() + RAND()) * (RAND() * RAND() / RAND()) + RAND())) ),"
             "`test_column5` = ( SELECT CONCAT(MD5(FLOOR((NOW() + RAND()) * (RAND() * RAND() / RAND()) + RAND())), '@', MD5(FLOOR((NOW() + RAND()) * (RAND() * RAND() / RAND()) + RAND())), '.com') ),"

--- a/tests/database/mysql/test_query_factory.py
+++ b/tests/database/mysql/test_query_factory.py
@@ -183,7 +183,7 @@ def test_get_update_table_fake_column(column_strategy_list):
             "UPDATE `anon_table` SET "
             "`test_column1` = ( SELECT `first_name` FROM `seed_table` ORDER BY RAND() LIMIT 1),"
             "`test_column2` = ( SELECT `last_name` FROM `seed_table` ORDER BY RAND() LIMIT 1),"
-            "`test_column7` = ( SELECT `user_id::UUID` FROM `seed_table` ORDER BY RAND() LIMIT 1),"
+            "`test_column7` = ( SELECT CAST(`user_id` AS UUID) FROM `seed_table` ORDER BY RAND() LIMIT 1),"
             "`test_column3` = (''),"
             "`test_column4` = ( SELECT MD5(FLOOR((NOW() + RAND()) * (RAND() * RAND() / RAND()) + RAND())) ),"
             "`test_column5` = ( SELECT CONCAT(MD5(FLOOR((NOW() + RAND()) * (RAND() * RAND() / RAND()) + RAND())), '@', MD5(FLOOR((NOW() + RAND()) * (RAND() * RAND() / RAND()) + RAND())), '.com') ),"

--- a/tests/database/mysql/test_query_factory.py
+++ b/tests/database/mysql/test_query_factory.py
@@ -64,7 +64,7 @@ def int_fake_column_generator():
 @pytest.fixture
 def uuid_fake_column_generator():
     return Mock(
-        get_data_type=Mock(return_value="UUID"),
+        get_data_type=Mock(return_value=FakeDataType.STRING),
         get_value=Mock(return_value="d4b7d972-99c9-4c0f-83c0-4cf2c63fd6ed")
     )
 

--- a/tests/database/postgres/test_query_factory.py
+++ b/tests/database/postgres/test_query_factory.py
@@ -14,9 +14,9 @@ from pynonymizer.strategy.update_column import (
 import pynonymizer.database.postgres.query_factory as query_factory
 
 """
-These tests are brittle and based on the actual SQL generatedColumnStrategyTypes. 
+These tests are brittle and based on the actual SQL generatedColumnStrategyTypes.
 The sentiment is to test the 'meaning' of the SQL, rather than the actual formatting, so it may be prudent to replace
-these tests with some form of parsing or pattern matching. 
+these tests with some form of parsing or pattern matching.
 
 The general idea, however, is that by keeping the queryfactory separate from the provider, it will not change often,
 and the sql returned should be very stable.
@@ -65,6 +65,12 @@ def int_fake_column_generator():
         get_data_type=Mock(return_value=FakeDataType.INT),
         get_value=Mock(return_value=645)
     )
+@pytest.fixture
+def uuid_fake_column_generator():
+    return Mock(
+        get_data_type=Mock(return_value="UUID"),
+        get_value=Mock(return_value="d4b7d972-99c9-4c0f-83c0-4cf2c63fd6ed")
+    )
 
 
 @pytest.fixture
@@ -76,6 +82,9 @@ def fake_update_column_str_first_name(str_fake_column_generator):
 def fake_update_column_int_last_name(int_fake_column_generator):
     return FakeUpdateColumnStrategy("test_column2",int_fake_column_generator, "last_name")
 
+@pytest.fixture
+def fake_update_column_uuid_user_id(uuid_fake_column_generator):
+    return FakeUpdateColumnStrategy("test_column7", uuid_fake_column_generator, "user_id", sql_type="UUID")
 
 @pytest.fixture
 def empty_strategy():
@@ -112,10 +121,11 @@ def qualifier_column_map(fake_update_column_str_first_name,fake_update_column_in
 
 
 @pytest.fixture
-def column_strategy_list(fake_update_column_str_first_name,fake_update_column_int_last_name,empty_strategy,ulogin_strategy, uemail_strategy,literal_strategy):
+def column_strategy_list(fake_update_column_str_first_name,fake_update_column_int_last_name,fake_update_column_uuid_user_id,empty_strategy,ulogin_strategy, uemail_strategy,literal_strategy):
     return [
         fake_update_column_str_first_name,
         fake_update_column_int_last_name,
+        fake_update_column_uuid_user_id,
         empty_strategy,
         ulogin_strategy,
         uemail_strategy,
@@ -175,6 +185,7 @@ def test_get_update_table_fake_column(column_strategy_list):
             "UPDATE anon_table AS \"updatetarget\" SET "
             "\"test_column1\" = ( SELECT first_name FROM seed_table WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1),"
             "\"test_column2\" = ( SELECT last_name FROM seed_table WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1),"
+            "\"test_column7\" = ( SELECT user_id::UUID FROM seed_table WHERE \"updatetarget\"=\"updatetarget\" ORDER BY RANDOM() LIMIT 1),"
             "\"test_column3\" = (''),"
             "\"test_column4\" = ( SELECT md5(random()::text) WHERE \"updatetarget\"=\"updatetarget\" ),"
             "\"test_column5\" = ( SELECT CONCAT(md5(random()::text), '@', md5(random()::text), '.com') WHERE \"updatetarget\"=\"updatetarget\" ),"

--- a/tests/database/postgres/test_query_factory.py
+++ b/tests/database/postgres/test_query_factory.py
@@ -68,7 +68,7 @@ def int_fake_column_generator():
 @pytest.fixture
 def uuid_fake_column_generator():
     return Mock(
-        get_data_type=Mock(return_value="UUID"),
+        get_data_type=Mock(return_value=FakeDataType.STRING),
         get_value=Mock(return_value="d4b7d972-99c9-4c0f-83c0-4cf2c63fd6ed")
     )
 

--- a/tests/strategy/test_update_column.py
+++ b/tests/strategy/test_update_column.py
@@ -92,3 +92,12 @@ def test_fake_update_where():
     assert fake_update_where.fake_type == "company_email"
     assert fake_update_where.where_condition == "chickens = 1"
 
+def test_fake_update_sql_type():
+    fake_column_generator = Mock()
+    fake_update_sql_type = FakeUpdateColumnStrategy(column_name="column_name",fake_column_generator=fake_column_generator, fake_type="company_email", sql_type="UUID")
+
+    assert fake_update_sql_type.strategy_type == UpdateColumnStrategyTypes.FAKE_UPDATE
+    assert fake_update_sql_type.value == fake_column_generator.get_value("company_email")
+    assert fake_update_sql_type.data_type == fake_column_generator.get_data_type("company_email")
+    assert fake_update_sql_type.fake_type == "company_email"
+    assert fake_update_sql_type.sql_type == "UUID"


### PR DESCRIPTION
# New feature

Add a new field to the following column strategies:

- literal
- fake_update

It allows user to define it's own SQL type. This is to override a limitation of types.

## Use case

With the following database schema in PostgreSQL:

```sql
CREATE TABLE foo (
    id uuid PRIMARY KEY,
    sensitive_data uuid
);
```

If I write the following strategy file:

```yaml
tables:
  foo:
    columns:
      sensitive_data: uuid4
```

We got the following error:

```
ERROR:  column "sensitive_data" is of type uuid but expression is of type character varying
```

## Solution

To overcome this issue, we could fix the strategy file by writing this:

```yaml
tables:
  foo:
    columns:
      sensitive_data:
        type: fake_update
        fake_type: uuid4
        sql_type: uuid # <--- new field
```

In the seed table, we will have the correct data type to update `foo` table.
