### PR TITLE
feat: output to .xz files

### DIFF
--- a/pynonymizer/database/basic/output.py
+++ b/pynonymizer/database/basic/output.py
@@ -1,4 +1,5 @@
 import gzip
+import lzma
 import os
 import sys
 """
@@ -18,6 +19,12 @@ class GzipOutput:
     def open(self):
         return gzip.open(self.filename, "wb")
 
+class XzOutput:
+    def __init__(self, filename):
+        self.filename = filename
+
+    def open(self):
+        return lzma.open(self.filename, "wb")
 
 class RawOutput:
     def __init__(self, filename):
@@ -40,5 +47,7 @@ def resolve_output(filename):
         return RawOutput(filename)
     elif ext == ".gz":
         return GzipOutput(filename)
+    elif ext == ".xz":
+        return XzOutput(filename)
     else:
         raise UnknownOutputTypeError(filename)

--- a/tests/database/basic/test_output.py
+++ b/tests/database/basic/test_output.py
@@ -1,4 +1,4 @@
-from pynonymizer.database.basic.output import UnknownOutputTypeError, resolve_output, RawOutput, GzipOutput, StdOutOutput
+from pynonymizer.database.basic.output import UnknownOutputTypeError, resolve_output, RawOutput, GzipOutput, StdOutOutput, XzOutput
 from unittest.mock import mock_open, patch
 import pytest
 
@@ -21,6 +21,11 @@ def test_resolve_raw(path_example):
 def test_resolve_gzip(path_example):
     test_path = path_example + "test.sql.gz"
     assert isinstance(resolve_output(test_path), GzipOutput)
+
+@pytest.mark.parametrize("path_example", test_path_examples)
+def test_resolve_xz(path_example):
+    test_path = path_example + "test.sql.xz"
+    assert isinstance(resolve_output(test_path), XzOutput)
 
 
 def test_resolve_unknown():


### PR DESCRIPTION
`xz` is more efficient at compression than `gzip`. This change adds support for outputting anonymized dumps as `.xz` files.
