### PR TITLE
add parentheses shorthand for literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+- Added a new compact syntax for column strategy `literal`. Surrounding your value in parentheses `()` will select the literal strategy. 
 
 ## [1.18.1] 2021-04-12
 - Fixed a fatal error when deprecated environment vars were used (See 1.2.0 notes for a full list).

--- a/doc/strategyfiles.md
+++ b/doc/strategyfiles.md
@@ -16,6 +16,7 @@ tables:
       password: empty
       current_sign_in_ip: ipv4_public
       last_sign_in_ip: ipv4_public
+      created_at: ( NOW() )
       username: user_name
       email:
         type: fake_update
@@ -176,7 +177,8 @@ column_name:
   type: literal
   value: RAND()
 
-# Compact Syntax: Not available
+# Compact Syntax: add parentheses around your value
+column_name: ( RAND() )
 ```
 
 ##### Column Strategy: `fake_update`

--- a/pynonymizer/strategy/parser.py
+++ b/pynonymizer/strategy/parser.py
@@ -63,6 +63,11 @@ class StrategyParser:
                 return {
                     "type": UpdateColumnStrategyTypes.UNIQUE_LOGIN.value
                 }
+            elif column_config.startswith("(") and column_config.endswith(")"):
+                return {
+                    "type": UpdateColumnStrategyTypes.LITERAL.value,
+                    "value": column_config
+                }
 
             else:
                 # Can't match it to anything special, must be a fake_update type. move the value to the fake_type field

--- a/tests/strategy/test_parser.py
+++ b/tests/strategy/test_parser.py
@@ -20,6 +20,7 @@ def simple_config():
                     "username": "unique_login",
                     "email": "unique_email",
                     "name": "empty",
+                    "raw": "(NOW())"
                 }
             },
             "secrets" : "delete",
@@ -91,14 +92,18 @@ def test_simple_parse_delete(simple_config, strategy_parser):
     assert table.strategy_type == TableStrategyTypes.DELETE
 
 
-    # need a better matching technique than checking list indicies.
-    """
-    assert accounts_strategy.column_strategies[0].strategy_type == UpdateColumnStrategyTypes.FAKE_UPDATE
+def test_simple_parse_columns(simple_config, strategy_parser):
+    strategy = strategy_parser.parse_config(simple_config)
 
-    assert accounts_strategy.column_strategies[1].strategy_type == UpdateColumnStrategyTypes.UNIQUE_LOGIN
-    assert accounts_strategy.column_strategies[2].strategy_type == UpdateColumnStrategyTypes.UNIQUE_EMAIL
-    assert accounts_strategy.column_strategies[3].strategy_type == UpdateColumnStrategyTypes.EMPTY
-    """
+    table = strategy.table_strategies[0]
+
+    # this is pretty rigid - it will also test strat order as well. not ideal!
+    assert table.column_strategies[0].strategy_type == UpdateColumnStrategyTypes.FAKE_UPDATE
+    assert table.column_strategies[1].strategy_type == UpdateColumnStrategyTypes.UNIQUE_LOGIN
+    assert table.column_strategies[2].strategy_type == UpdateColumnStrategyTypes.UNIQUE_EMAIL
+    assert table.column_strategies[3].strategy_type == UpdateColumnStrategyTypes.EMPTY
+    assert table.column_strategies[4].strategy_type == UpdateColumnStrategyTypes.LITERAL
+    assert table.column_strategies[4].value == "(NOW())"
 
 
 


### PR DESCRIPTION
You can now shorthand literals by putting `()` around them!

* updated unit tests
* updated docs