### PR TITLE
attempt to detect higher-numbered drivers first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Added a new compact syntax for column strategy `literal`. Surrounding your value in parentheses `()` will select the literal strategy. 
 - Improvements to mssql driver auto-selection process, to attempt to select a more recent driver by default.
+- Fixed a bug where on a system with no ODBC drivers, an incorrect error would be thrown.
 
 ## [1.18.1] 2021-04-12
 - Fixed a fatal error when deprecated environment vars were used (See 1.2.0 notes for a full list).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   -------------------------------------------------------------------
 ## [Unreleased]
 - Added a new compact syntax for column strategy `literal`. Surrounding your value in parentheses `()` will select the literal strategy. 
+- Improvements to mssql driver auto-selection process, to attempt to select a more recent driver by default.
 
 ## [1.18.1] 2021-04-12
 - Fixed a fatal error when deprecated environment vars were used (See 1.2.0 notes for a full list).

--- a/pynonymizer/database/mssql/__init__.py
+++ b/pynonymizer/database/mssql/__init__.py
@@ -69,13 +69,13 @@ class MsSqlProvider(DatabaseProvider):
         
         ms_drivers = [i for i in pyodbc.drivers() if "sql server" in i.lower()]
         if len(ms_drivers) < 1:
-            raise DependencyError("Failed to detect any ODBC drivers on this system.")
+            raise DependencyError("odbc", "Failed to detect any ODBC drivers on this system.")
 
         if len(ms_drivers) > 1:
             self.logger.debug("multiple drivers detected for mssql: %s", ms_drivers)
 
         # Sort by the highest number (like, ODBC driver 14 for SQL server)
-        return sorted(ms_drivers, key=extract_version, reverse=True)[0]
+        return sorted(ms_drivers, key=_extract_driver_version, reverse=True)[0]
 
     def __require_local_server(self):
         if self.db_host != _LOCAL_SERVER:

--- a/tests/database/mssql/test_provider.py
+++ b/tests/database/mssql/test_provider.py
@@ -41,6 +41,28 @@ def mock_backup_side_effect(statement, *args, **kwargs):
 
     return Mock()
 
+@patch("pyodbc.connect")
+@patch("pyodbc.drivers", return_value=['SQL Server', 'SQL Server Native Client 11.0', 'SQL Server Native Client RDA 11.0', 'ODBC Driver 17 for SQL Server', 'ODBC Driver 13 for SQL Server', 'Microsoft Access Driver (*.mdb, *.accdb)', 'Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)', 'Microsoft Access Text Driver (*.txt, *.csv)'])
+def test_detect_drivers__when_many_drivers__should_connect_with_highest_numbered(drivers, connect):
+    provider = MsSqlProvider("192.168.2.1", "username", "password", "dbname")
+    provider.drop_database()
+
+    connect.assert_any_call(
+        driver="{ODBC Driver 17 for SQL Server}",
+        server="192.168.2.1,1433",
+        uid="username",
+        pwd="password",
+        autocommit=True
+    )
+
+    
+
+
+
+@patch("pyodbc.drivers", return_value=[])
+def test_detect_drivers__when_no_drivers__raises_dependencyerror(drivers):
+    with pytest.raises(DependencyError):
+        MsSqlProvider("192.168.2.1", "username", "password", "dbname")
 
 def test_raise_on_remote_server_backup():
     provider = MsSqlProvider("192.168.2.1", "username", "password", "dbname", driver="driver")


### PR DESCRIPTION
I've also downgraded the multi-driver warning to a debug log, since it seems likely that multiple drivers would be available on most systems with ssms/mssql. 