### PR TITLE
fixed locale override and added corresponding tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+- Fixed a bug in the config parser that would always override the locale with either the cli argument or the fallback
+
 ## [1.21.0] 2021-05-31
 - Added Custom Providers to strategyfiles. You can now include custom Faker providers in your
   strategyfiles, using the `providers` top-level key.

--- a/pynonymizer/pynonymize.py
+++ b/pynonymizer/pynonymize.py
@@ -44,9 +44,6 @@ def pynonymize(
     if db_type is None:
         db_type = "mysql"
 
-    if fake_locale is None:
-        fake_locale = "en_GB"
-
     if seed_rows is None:
         seed_rows = 150
 

--- a/pynonymizer/strategy/parser.py
+++ b/pynonymizer/strategy/parser.py
@@ -167,7 +167,7 @@ class StrategyParser:
         """
         config = StrategyParser.__normalize_table_list(deepcopy(raw_config))
 
-        locale = config.get("locale", None)
+        locale = config.get("locale", "en_GB")
         if locale_override:
             locale = locale_override
 

--- a/tests/strategy/test_parser.py
+++ b/tests/strategy/test_parser.py
@@ -1,7 +1,7 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from pynonymizer.fake import UnsupportedFakeTypeError
+from pynonymizer.fake import UnsupportedFakeTypeError, FakeColumnGenerator
 from pynonymizer.strategy import database
 from pynonymizer.strategy.exceptions import UnknownTableStrategyError, UnknownColumnStrategyError, ConfigSyntaxError
 from pynonymizer.strategy.table import TableStrategyTypes
@@ -255,3 +255,50 @@ def test_table_raises_when_given_unrelated_key(strategy_parser):
                 }
             }
         })
+
+
+def test_locale_set_in_strategy_file_strategy_parse(strategy_parser):
+    with patch.object(FakeColumnGenerator, "__init__", return_value=None) as mocked_fake_column_generator:
+        strategy_parser.parse_config(
+            {
+                "tables": [
+                    {
+                        "table_name": "table1",
+                        "type": "truncate",
+                    },
+                ],
+                "locale": "de_DE"
+            }
+        )
+        mocked_fake_column_generator.assert_called_with(locale='de_DE', providers=[])
+
+
+def test_locale_not_set_in_strategy_file_strategy_parse(strategy_parser):
+    with patch.object(FakeColumnGenerator, "__init__", return_value=None) as mocked_fake_column_generator:
+        strategy_parser.parse_config(
+            {
+                "tables": [
+                    {
+                        "table_name": "table1",
+                        "type": "truncate",
+                    },
+                ]
+            }
+        )
+        mocked_fake_column_generator.assert_called_with(locale='en_GB', providers=[])
+
+
+def test_locale_set_via_argument_strategy_parse(strategy_parser):
+    with patch.object(FakeColumnGenerator, "__init__", return_value=None) as mocked_fake_column_generator:
+        strategy_parser.parse_config(
+            {
+                "tables": [
+                    {
+                        "table_name": "table1",
+                        "type": "truncate",
+                    },
+                ]
+            },
+            locale_override="ja_JP"
+        )
+        mocked_fake_column_generator.assert_called_with(locale='ja_JP', providers=[])


### PR DESCRIPTION
The current code does not allow for setting the locale in the strategyfile by always overwriting it as described in this issue: https://github.com/jerometwell/pynonymizer/issues/78