### PR TITLE
Fix bug with literal column configs containing `type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+- Fixed a bug in the config parser where literal column strategies that contained `type` threw an error
 
 ## [1.21.1] 2021-06-22
 - Fixed a bug in the config parser that would always override the locale with either the cli argument or the fallback

--- a/pynonymizer/strategy/parser.py
+++ b/pynonymizer/strategy/parser.py
@@ -49,8 +49,11 @@ class StrategyParser:
 
     @staticmethod
     def __normalize_column_config(column_config):
-        # If the column config doesn't have a "type" specified, it needs to be determined automatically.
-        if "type" not in column_config:
+        if isinstance(column_config, dict) and "type" in column_config:
+            return column_config
+
+        # If the column config is not a dict with "type" specified, the type needs to be determined automatically.
+        else:
             if column_config == "empty":
                 return {
                     "type": UpdateColumnStrategyTypes.EMPTY.value
@@ -77,8 +80,6 @@ class StrategyParser:
                     "type": UpdateColumnStrategyTypes.FAKE_UPDATE.value,
                     "fake_type": column_config
                 }
-        else:
-            return column_config
 
     @staticmethod
     def __normalize_table_list(config):
@@ -102,7 +103,7 @@ class StrategyParser:
             for column_name, column_config in columns_config.items():
                 normalized_column = StrategyParser.__normalize_column_config(column_config)
                 normalized_column["column_name"] = column_name
-                column_list.append( normalized_column )
+                column_list.append(normalized_column)
 
             return column_list
 

--- a/tests/strategy/test_parser.py
+++ b/tests/strategy/test_parser.py
@@ -142,6 +142,20 @@ def test_unknown_column_strategy(strategy_parser):
         })
 
 
+def test_column_strategy_literal_containing_type(strategy_parser):
+    strategy_parser.parse_config({
+        "tables": {
+            "accounts": {
+                "columns": {
+                    "current_sign_in_ip": "(content_type_id)"  # Valid literal strategy shorthand containing "type"
+                }
+            },
+
+            "transactions": "truncate"
+        }
+    })
+
+
 def test_unknown_table_strategy_bad_dict(strategy_parser):
     with pytest.raises(UnknownTableStrategyError):
         strategy_parser.parse_config({


### PR DESCRIPTION
Currently, there's an issue with the parser where the column strategy is assumed to be a dict if it contains `type`. This breaks if the column strategy is a string that happens to contain `type` as a substring, because the parser incorrectly assumes it's a dict with `type` as a key.