### PR TITLE
Close batch_processor stdin stream permanently when dump restoration is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   -------------------------------------------------------------------
 ## [Unreleased]
 - Added a workflow that automatically runs `black` on incoming PRs, to set a canonical standard for formatting in the project.
+- Fixed a bug in mysql/postgres where stdin is not closed after reading
 
 ## [1.21.2] 2021-09-06
 - Fixed a bug in the config parser where literal column strategies that contained `type` threw an error

--- a/pynonymizer/database/mysql/__init__.py
+++ b/pynonymizer/database/mysql/__init__.py
@@ -182,19 +182,22 @@ class MySqlProvider(DatabaseProvider):
         input_obj = resolve_input(input_path)
         dumpsize = input_obj.get_size()
 
-        batch_processor = self.__runner.open_batch_processor()
-        with input_obj.open() as dumpfile_data:
-            with tqdm(
-                desc="Restoring",
-                total=dumpsize,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1000,
-            ) as bar:
-                for chunk in self.__read_until_empty_byte(dumpfile_data):
-                    batch_processor.write(chunk)
-                    batch_processor.flush()
-                    bar.update(len(chunk))
+        try:
+            batch_processor = self.__runner.open_batch_processor()
+            with input_obj.open() as dumpfile_data:
+                with tqdm(
+                    desc="Restoring",
+                    total=dumpsize,
+                    unit="B",
+                    unit_scale=True,
+                    unit_divisor=1000,
+                ) as bar:
+                    for chunk in self.__read_until_empty_byte(dumpfile_data):
+                        batch_processor.write(chunk)
+                        batch_processor.flush()
+                        bar.update(len(chunk))
+        finally:
+            batch_processor.close()
 
     def dump_database(self, output_path):
         """

--- a/pynonymizer/database/postgres/__init__.py
+++ b/pynonymizer/database/postgres/__init__.py
@@ -182,18 +182,21 @@ class PostgreSqlProvider(DatabaseProvider):
         dumpsize = input_obj.get_size()
 
         batch_processor = self.__runner.open_batch_processor()
-        with input_obj.open() as dumpfile_data:
-            with tqdm(
-                desc="Restoring",
-                total=dumpsize,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1000,
-            ) as bar:
-                for chunk in self.__read_until_empty_byte(dumpfile_data):
-                    batch_processor.write(chunk)
-                    batch_processor.flush()
-                    bar.update(len(chunk))
+        try:
+            with input_obj.open() as dumpfile_data:
+                with tqdm(
+                    desc="Restoring",
+                    total=dumpsize,
+                    unit="B",
+                    unit_scale=True,
+                    unit_divisor=1000,
+                ) as bar:
+                    for chunk in self.__read_until_empty_byte(dumpfile_data):
+                        batch_processor.write(chunk)
+                        batch_processor.flush()
+                        bar.update(len(chunk))
+        finally:
+            batch_processor.close()
 
     def dump_database(self, output_path):
         """


### PR DESCRIPTION
### Description
I am running `pynonymizer` programmatically and noticed that after each run there is a dangling MySQL connection (same is expected for PostgreSQL):
```
mysql -h database-host -P 3306 -u user -px xx --ssl my_db
```

This piles up quite quickly.

### Fix
I narrowed it down to `restore_database` in `pynonymizer/database/mysql/__init__py` where a `batch_processor` is created via `subprocess.Popen(..).stdin` but never closed.

### Setup
- Python: `Python 3.9.7 (default, Sep 28 2021, 18:41:28)`
- Pynonymizer: `1.21.2`